### PR TITLE
Fix ヘルスチェックのログ出力を無効化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'puma', '~> 5.0'
 gem 'rack-cors'
 gem 'rails', '~> 7.0.3', '>= 7.0.3.1'
 gem 'rails-i18n'
+gem 'silencer'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
     ruby-progressbar (1.11.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
+    silencer (2.0.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -270,6 +271,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   shoulda-matchers
+  silencer
   simplecov
   tzinfo-data
 

--- a/config/initializers/silencer.rb
+++ b/config/initializers/silencer.rb
@@ -1,0 +1,11 @@
+require 'silencer/rails/logger'
+
+# AWSのログがヘルスチェックで埋まるため、ヘルスチェックのみログを出力しない
+Rails.application.configure do
+  config.middleware.swap(
+    Rails::Rack::Logger,
+    Silencer::Logger,
+    config.log_tags,
+    silence: ['/health_check']
+  )
+end


### PR DESCRIPTION
AWSのログがヘルスチェックで埋まるため、ヘルスチェックのみログを出力させないようにした